### PR TITLE
apple/t2: Update linux-t2-arch patches to latest commit

### DIFF
--- a/apple/t2/pkgs/t2-linux.nix
+++ b/apple/t2/pkgs/t2-linux.nix
@@ -5,7 +5,7 @@ let
     owner = "Redecorating";
     repo = "linux-t2-arch";
     rev = "ede033e1549091cda1471114f9d77f1053c40132";
-    sha256 = "sha256-0pz282kjwa757mcx35aha2lgvn8py9wx051zw0dh2qnls8qmay0w";
+    sha256 = "0pz282kjwa757mcx35aha2lgvn8py9wx051zw0dh2qnls8qmay0w";
   };
 
   version = "5.19.12";

--- a/apple/t2/pkgs/t2-linux.nix
+++ b/apple/t2/pkgs/t2-linux.nix
@@ -5,7 +5,7 @@ let
     owner = "Redecorating";
     repo = "linux-t2-arch";
     rev = "ede033e1549091cda1471114f9d77f1053c40132";
-    sha256 = "0pz282kjwa757mcx35aha2lgvn8py9wx051zw0dh2qnls8qmay0w";
+    sha256 = "sha256-HHhVMdLUYgEb4D8U0HnyF9n9qFBQldFZPeUoLqdA4l8=";
   };
 
   version = "5.19.12";

--- a/apple/t2/pkgs/t2-linux.nix
+++ b/apple/t2/pkgs/t2-linux.nix
@@ -5,7 +5,7 @@ let
     owner = "Redecorating";
     repo = "linux-t2-arch";
     rev = "ede033e1549091cda1471114f9d77f1053c40132";
-    sha256 = "sha256-HHhVMdLUYgEb4D8U0HnyF9n9qFBQldFZPeUoLqdA4l8=";
+    sha256 = "sha256-HHhVMdLBYgEb4D8U0HnyF9n9qFBQldFZPeUoLqdA4l8=";
   };
 
   version = "5.19.12";

--- a/apple/t2/pkgs/t2-linux.nix
+++ b/apple/t2/pkgs/t2-linux.nix
@@ -4,8 +4,8 @@ let
   patchRepo = fetchFromGitHub {
     owner = "Redecorating";
     repo = "linux-t2-arch";
-    rev = "65a5575de77284c0a36c95510ebaaa8e8a867bc5";
-    sha256 = "sha256-c5cTWLyGsuudyvz3PIDgJ7sd8veB/x6z/XpsK7M82lY=";
+    rev = "ede033e1549091cda1471114f9d77f1053c40132";
+    sha256 = "sha256-0pz282kjwa757mcx35aha2lgvn8py9wx051zw0dh2qnls8qmay0w";
   };
 
   version = "5.19.12";


### PR DESCRIPTION
Update includes 7a7e3c123d620fb529115a746fd807be0e643747, which fixes swap_fn_leftctrl on some devices.