### PR TITLE
fixed keyboard and trackpad unresponsiveness after wake from suspend

### DIFF
--- a/apple/t2/default.nix
+++ b/apple/t2/default.nix
@@ -22,7 +22,8 @@ in
 {
   # For keyboard and touchbar
   boot.kernelPackages = with pkgs; recurseIntoAttrs (linuxPackagesFor (callPackage ./pkgs/linux-t2.nix {}));
-  boot.initrd.kernelModules = [ "apple-bce" ];
+  boot.initrd.kernelModules = [ "apple_bce" ];
+  boot.kernelModules = [ "apple_touchbar" ];
 
   # For audio
   boot.kernelParams = [ "pcie_ports=compat" "intel_iommu=on" "iommu=pt" ];
@@ -39,10 +40,5 @@ in
     wireplumber.package = pkgs.wireplumber.override {
       pipewire = package;
     };
-  };
-
-  powerManagement = {
-    powerUpCommands = "${pkgs.kmod}/bin/modprobe apple_touchbar";
-    powerDownCommands = "${pkgs.kmod}/bin/rmmod apple_touchbar";
   };
 }


### PR DESCRIPTION
I noticed that after waking from suspend, both the keyboard and trackpad were unresponsive, and prevented systemd from shutting down gracefully. I saw this [module refresh hack](https://github.com/kekrby/nixos-hardware/blob/e964f9f56c01992263c0b8040f989996aa870741/apple/t2/default.nix#L44-L47C5) and I noticed a similar suspend fix was [removed upstream](https://github.com/t2linux/wiki/pull/385) after Apple touchbar drivers were fixed. My changes fix this problem on my machine, but I am a total NixOS noob — please correct me if there is a reason to leave this in.

Also: This is not directly related to the bug preventing keyboard/trackpad from working after suspend, but I wonder if `mem_sleep_default=s2idle` should be made a default kernel parameter. Obviously this can be set by the user, but s2idle seems like a much more sane default than suspend-to-RAM. I haven't fully tested the effect on battery life, but I'm noticing significant time savings on wake from suspend (10s to 0.5s) with no noticeable battery drainage. Let me know what you think.